### PR TITLE
feat: improve report message

### DIFF
--- a/copyloopvar.go
+++ b/copyloopvar.go
@@ -66,7 +66,7 @@ func checkRangeStmt(pass *analysis.Pass, rangeStmt *ast.RangeStmt) {
 			}
 			pass.Report(analysis.Diagnostic{
 				Pos:     assignStmt.Pos(),
-				Message: fmt.Sprintf(`It's unnecessary to copy the loop variable "%s"`, right.Name),
+				Message: fmt.Sprintf(`The copy of the 'for' variable "%s" can be deleted (Go 1.22+)`, right.Name),
 			})
 		}
 	}
@@ -104,7 +104,7 @@ func checkForStmt(pass *analysis.Pass, forStmt *ast.ForStmt) {
 			}
 			pass.Report(analysis.Diagnostic{
 				Pos:     assignStmt.Pos(),
-				Message: fmt.Sprintf(`It's unnecessary to copy the loop variable "%s"`, right.Name),
+				Message: fmt.Sprintf(`The copy of the 'for' variable "%s" can be deleted (Go 1.22+)`, right.Name),
 			})
 		}
 	}

--- a/testdata/src/a/main.go
+++ b/testdata/src/a/main.go
@@ -2,20 +2,20 @@ package a
 
 func f() {
 	for i, v := range []int{1, 2, 3} {
-		i := i  // want `It's unnecessary to copy the loop variable "i"`
-		_v := v // want `It's unnecessary to copy the loop variable "v"`
+		i := i  // want `The copy of the 'for' variable "i" can be deleted \(Go 1\.22\+\)`
+		_v := v // want `The copy of the 'for' variable "v" can be deleted \(Go 1\.22\+\)`
 		_ = i
 		_ = _v
 	}
 
 	for i := 1; i <= 3; i++ {
-		i := i // want `It's unnecessary to copy the loop variable "i"`
+		i := i // want `The copy of the 'for' variable "i" can be deleted \(Go 1\.22\+\)`
 		_ = i
 	}
 
 	for i, j := 1, 1; i+j <= 3; i++ {
-		i := i       // want `It's unnecessary to copy the loop variable "i"`
-		j, _ := j, 1 // want `It's unnecessary to copy the loop variable "j"`
+		i := i       // want `The copy of the 'for' variable "i" can be deleted \(Go 1\.22\+\)`
+		j, _ := j, 1 // want `The copy of the 'for' variable "j" can be deleted \(Go 1\.22\+\)`
 		_, _ = i, j
 	}
 }


### PR DESCRIPTION

Before:
```
It's unnecessary to copy the loop variable "a"
```

After:
```
The copy of the 'for' variable "a" can be deleted (Go 1.22+)
```