### PR TITLE
fix: panic when rangeStmt value's type is not `*ast.Ident`

### DIFF
--- a/copyloopvar.go
+++ b/copyloopvar.go
@@ -52,7 +52,9 @@ func checkRangeStmt(pass *analysis.Pass, rangeStmt *ast.RangeStmt) {
 	}
 	var value *ast.Ident
 	if rangeStmt.Value != nil {
-		value = rangeStmt.Value.(*ast.Ident)
+		if value, ok = rangeStmt.Value.(*ast.Ident); !ok {
+			return
+		}
 	}
 	for _, stmt := range rangeStmt.Body.List {
 		assignStmt, ok := stmt.(*ast.AssignStmt)

--- a/testdata/src/basic/main.go
+++ b/testdata/src/basic/main.go
@@ -20,4 +20,11 @@ func main() {
 		c, d := 1, j // want `The copy of the 'for' variable "j" can be deleted \(Go 1\.22\+\)`
 		_, _, _, _, _, _, _, _ = i, _i, j, _j, a, b, c, d
 	}
+
+	var t struct {
+		Bool bool
+	}
+	for _, t.Bool = range []bool{true, false} {
+		_ = t
+	}
 }

--- a/testdata/src/ignorealias/main.go
+++ b/testdata/src/ignorealias/main.go
@@ -20,4 +20,11 @@ func main() {
 		c, d := 1, j
 		_, _, _, _, _, _, _, _ = i, _i, j, _j, a, b, c, d
 	}
+
+	var t struct {
+		Bool bool
+	}
+	for _, t.Bool = range []bool{true, false} {
+		_ = t
+	}
 }


### PR DESCRIPTION
Fix panic when rangeStmt value's type is not `*ast.Ident`.

resolve https://github.com/karamaru-alpha/copyloopvar/issues/7