### PR TITLE
fix: suggested fixes

### DIFF
--- a/copyloopvar.go
+++ b/copyloopvar.go
@@ -134,7 +134,7 @@ func report(pass *analysis.Pass, assignStmt *ast.AssignStmt, right *ast.Ident, i
 		Message: fmt.Sprintf(`The copy of the 'for' variable "%s" can be deleted (Go 1.22+)`, right.Name),
 	}
 
-	if i == 1 && isSimpleAssignStmt(assignStmt, right) {
+	if i == 0 && isSimpleAssignStmt(assignStmt, right) {
 		diagnostic.SuggestedFixes = append(diagnostic.SuggestedFixes, analysis.SuggestedFix{
 			TextEdits: []analysis.TextEdit{{
 				Pos:     assignStmt.Pos(),
@@ -157,5 +157,5 @@ func isSimpleAssignStmt(assignStmt *ast.AssignStmt, rhs *ast.Ident) bool {
 		return false
 	}
 
-	return rhs == lhs
+	return rhs.Name == lhs.Name
 }

--- a/copyloopvar_test.go
+++ b/copyloopvar_test.go
@@ -35,7 +35,23 @@ func TestAnalyzer(t *testing.T) {
 				}
 			}
 
-			analysistest.RunWithSuggestedFixes(t, analysistest.TestData(), analyzer, test.dir)
+			results := analysistest.RunWithSuggestedFixes(t, analysistest.TestData(), analyzer, test.dir)
+
+			hasSuggestedFixes(t, results)
 		})
 	}
+}
+
+func hasSuggestedFixes(t *testing.T, results []*analysistest.Result) {
+	t.Helper()
+
+	for _, result := range results {
+		for _, diagnostic := range result.Diagnostics {
+			if len(diagnostic.SuggestedFixes) > 0 {
+				return
+			}
+		}
+	}
+
+	t.Errorf("no suggested fixes found")
 }


### PR DESCRIPTION
If there are no suggested fixes, `analysistest.RunWithSuggestedFixes` doesn't check the `.golden` files.

~~I will open an issue on the `x/tools` about that. https://github.com/golang/go/issues/71130~~