### PR TITLE
go.mod: bump golang.org/x/tools to latest, go to 1.24.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Run test
         run: go test -v ./...
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.62
+          version: v2.5.0

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,10 @@
 module github.com/karamaru-alpha/copyloopvar
 
-go 1.21
+go 1.24.0
 
-require golang.org/x/tools v0.18.0
+require golang.org/x/tools v0.37.0
 
-require golang.org/x/mod v0.15.0 // indirect
+require (
+	golang.org/x/mod v0.28.0 // indirect
+	golang.org/x/sync v0.17.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
-golang.org/x/mod v0.15.0 h1:SernR4v+D55NyBH2QiEQrlBAnj1ECL6AGrA5+dPaMY8=
-golang.org/x/mod v0.15.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
-golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/tools v0.18.0 h1:k8NLag8AGHnn+PHbl7g43CtqZAwG60vZkLqgyZgIHgQ=
-golang.org/x/tools v0.18.0/go.mod h1:GL7B4CwcLLeo59yx/9UWWuNOW1n3VZ4f5axWfML7Lcg=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.28.0 h1:gQBtGhjxykdjY9YhZpSlZIsbnaE2+PgjfLWUQTnoZ1U=
+golang.org/x/mod v0.28.0/go.mod h1:yfB/L0NOf/kmEbXjzCPOx1iK1fRutOydrCMsqRhEBxI=
+golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
+golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/tools v0.37.0 h1:DVSRzp7FwePZW356yEAChSdNcQo6Nsp+fex1SUW09lE=
+golang.org/x/tools v0.37.0/go.mod h1:MBN5QPQtLMHVdvsbtarmTNukZDdgwdwlO5qGacAzF0w=


### PR DESCRIPTION
Attempting to build copyloopvar with Go 1.25 fails with:

    $ go version
    go version go1.25.1 linux/amd64
    $ go install github.com/karamaru-alpha/copyloopvar/cmd/copyloopvar@latest
    # golang.org/x/tools/internal/tokeninternal
    ../../../../pkg/mod/golang.org/x/tools@v0.18.0/internal/tokeninternal/tokeninternal.go:78:9: invalid array length -delta * delta (constant -256 of type int64)

Fix this by pulling in the latest version of the `golang.org/x/tools` package:

    $ go get golang.org/x/tools@latest
    go: upgraded go 1.21 => 1.24.0
    go: upgraded golang.org/x/mod v0.15.0 => v0.28.0
    go: upgraded golang.org/x/tools v0.18.0 => v0.37.0

This transitively also updates the Go version in `go.mod` to 1.24.0.