### PR TITLE
chore: upgrade actions; fix lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - name: Run test
         run: go test -v ./...
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.5.0
+          version: v2.11.3
+          args: --enable=modernize

--- a/copyloopvar.go
+++ b/copyloopvar.go
@@ -91,7 +91,7 @@ func checkForStmt(pass *analysis.Pass, forStmt *ast.ForStmt) {
 	if !ok {
 		return
 	}
-	initVarNameMap := make(map[string]interface{}, len(initAssignStmt.Lhs))
+	initVarNameMap := make(map[string]any, len(initAssignStmt.Lhs))
 	for _, lh := range initAssignStmt.Lhs {
 		if initVar, ok := lh.(*ast.Ident); ok {
 			initVarNameMap[initVar.Name] = struct{}{}


### PR DESCRIPTION
- Upgrade to `actions/checkout@v6` and `actions/setup-go@v6`.
- Upgrade `golangci-lint` to v2.11.3.
- Enable `modernize` linter.